### PR TITLE
chore(security): Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,11 @@
 name: Release
-permissions:
-  contents: read
 
 on: workflow_dispatch
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: read
 
 on: workflow_dispatch
 


### PR DESCRIPTION
Potential fix for [https://github.com/aagsolutions/teltonika-codec/security/code-scanning/1](https://github.com/aagsolutions/teltonika-codec/security/code-scanning/1)

To resolve the issue, you should set the `permissions` key with the least privilege required for the workflow. Since the workflow checks out code and runs a release step, but the shown steps do not directly require write access (e.g., to create releases on the GitHub UI), a bare minimum of `contents: read` is recommended. You can add this block either at the workflow root (applies to all jobs unless overridden), or inside the `build` job (applies just to that job). For clarity and maintainability, setting it at the workflow root is preferred unless specific jobs need escalation. This involves inserting:

```yml
permissions:
  contents: read
```

at line 2 (after the `name:` and before `on:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
